### PR TITLE
fix(schema): changed id to $id

### DIFF
--- a/packages/nx-python/src/schematics/nx-python/schema.json
+++ b/packages/nx-python/src/schematics/nx-python/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "id": "NxPython",
+  "$id": "NxPython",
   "title": "",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Fixes:
`Error: NOT SUPPORTED: keyword "id", use "$id" for schema ID`